### PR TITLE
Moved   into BaseController which checks and caches them instead of calling them everytime.

### DIFF
--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CarPartType;
+use App\Models\CarBrand;
+use Illuminate\Support\Facades\Cache;
+
+class BaseController extends Controller
+{
+    public $partTypes;
+    public $carBrands;
+
+    public function __construct()
+    {
+        $this->partTypes = Cache::remember('car_part_types', 3600, function () {
+            return CarPartType::all();
+        });
+
+        $this->carBrands = Cache::remember('car_brands', 3600, function () {
+            return CarBrand::all();
+        });
+
+        view()->share([
+            'partTypes' => $this->partTypes,
+            'carBrands' => $this->carBrands,
+        ]);
+    }
+
+}

--- a/app/Http/Controllers/CarPartController.php
+++ b/app/Http/Controllers/CarPartController.php
@@ -10,18 +10,15 @@ use App\Models\CarPart;
 use App\Models\CarPartType;
 use App\Models\DismantleCompany;
 use App\Models\DitoNumber;
-use App\Models\GermanDismantler;
 use App\Models\NewCarPart;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
-use Illuminate\View\View;
 use App\Actions\Parts\SortPartsAction;
 use Illuminate\Support\Facades\Cache;
 use App\Models\MainCategory;
 
 
-class CarPartController extends Controller
+class CarPartController extends BaseController
 {
 
     private const SEARCHABLE_COLUMNS = [
@@ -54,8 +51,6 @@ class CarPartController extends Controller
         $kba = null;
 
         $mainCategories = MainCategory::with('carPartTypes')->get();
-
-        $brands = CarBrand::all();
 
         $ditoNumber = null;
 
@@ -91,12 +86,10 @@ class CarPartController extends Controller
             ->with('carPartImages')
             ->paginate(9, pageName: 'parts');
 
-        $partTypes = CarPartType::all();
         $dismantleCompanies = DismantleCompany::all();
 
         return view('car-parts.index', compact(
             'parts',
-            'partTypes',
             'dismantleCompanies',
             'kba',
             'partsDifferentCarSameEngineType',
@@ -126,7 +119,6 @@ class CarPartController extends Controller
             $type = CarPartType::find($request->get('type_id'));
         }
 
-        // Begin building the query
         $parts = NewCarPart::with([
             'carPartType',
             'dismantleCompany',
@@ -165,9 +157,6 @@ class CarPartController extends Controller
             return CarBrand::all();
         });
 
-        $partTypes = Cache::remember('car_part_types', 60, function () {
-            return CarPartType::all();
-        });
 
         $dismantleCompanies = Cache::remember('dismantle_companies', 60, function () {
             return DismantleCompany::all();
@@ -176,7 +165,6 @@ class CarPartController extends Controller
         // Return the view with the filtered data
         return view('browse-car-parts', compact(
             'parts',
-            'partTypes',
             'type',
             'dismantleCompanies',
             'brands',
@@ -254,13 +242,11 @@ class CarPartController extends Controller
             'search' => $request->get('search'), // Include the new search term
         ];
 
-        $partTypes = CarPartType::all();
 
         // Return the view with the updated parts and search parameters
         return view('parts-kba', compact(
             'parts',
             'search',
-            'partTypes',
             'type',
             'kba',
             'partCount',
@@ -341,15 +327,11 @@ class CarPartController extends Controller
             'search' => $request->get('search'), // Secondary search term
         ];
 
-        // Get all car part types
-        $partTypes = CarPartType::all();
-
         return view('parts-model', compact(
             'parts',
             'search',
             'dito',
             'type',
-            'partTypes',
             'partCount',
             'mainCategories'
         ));
@@ -383,7 +365,6 @@ class CarPartController extends Controller
         }
 
         $parts = $results['data']['parts'];
-        $partTypes = CarPartType::all();
 
         return view('parts-oem', compact(
             'parts',
@@ -391,7 +372,6 @@ class CarPartController extends Controller
             'oem',
             'engine_code',
             'gearbox',
-            'partTypes',
             'mainCategories'
         ));
     }

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -6,15 +6,9 @@ use App\Models\Blog;
 use App\Models\CarBrand;
 use App\Models\CarPartType;
 use App\Models\ManufacturerText;
-use Illuminate\Http\Request;
 use Illuminate\View\View;
-use Illuminate\Support\Facades\App;
 use Mcamara\LaravelLocalization\Facades\LaravelLocalization;
-use App\Models\DitoNumber;
 use App\Models\MainCategory;
-use App\Models\NewCarPart;
-use Illuminate\Support\Str;
-
 
 class LandingPageController extends Controller
 {
@@ -37,7 +31,6 @@ class LandingPageController extends Controller
         $partTypes = CarPartType::all();
 
         $brands = CarBrand::all();
-
 
         $mainCategories = MainCategory::withPartsCount()->get();
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -145,7 +145,7 @@ Route::group(
         Route::post('categories/disconnect-car-part/{mainCategory}', [AdminCategoryController::class, 'disconnectCarPart'])->name('admin.categories.disconnect-car-part');
         // show individual category
         //Route::get('part-types-categories/{category}', [AdminCategoryController::class, 'show'])->name('admin.part-types-categories.show');
-    
+
         Route::resource('sbr-codes', \App\Http\Controllers\AdminSbrCodeController::class, ['as' => 'admin']);
         Route::resource('dito-numbers.sbr-codes', \App\Http\Controllers\AdminDitoNumberSbrCodeController::class, ['as' => 'admin'])->only(['index', 'show', 'store', 'destroy']);
 


### PR DESCRIPTION
Instead of calling  $partTypes = CarPartType::all(); & $brands = CarBrand::all(); everytime inside each method, we just call it the first time a method inside CarPartController is called, and store it in cache (BaseController) for an hour and then it just checks if its in cache and if its not it just calls it once and stores it in the cache for another hour. 

1. saves method calls
2. optimizes performance